### PR TITLE
Star Wars Bug Fix

### DIFF
--- a/star-wars-app/star-wars-app.js
+++ b/star-wars-app/star-wars-app.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
     wookieeSound6.setAttribute("src", "star-wars-app/sounds/wookieesound6.mp3");
 
     // When the selection on the dropdown changes...
-    $("select.planet-selection").change(function(){
+    $("select#planet-selection").change(function(){
         // Store the value of the selected planet into a variable
         selectedPlanet = $(this).children("option:selected").val();
     });


### PR DESCRIPTION
This feature fixes a bug where the Star Wars planets weren't populating correctly when the submit button was clicked.

planet-selection was changed from a class to an id on line 22 of the star-wars-app.js file.