### PR TITLE
Star Wars Empty Residents Array Bug Fix

### DIFF
--- a/star-wars-app/star-wars-app.js
+++ b/star-wars-app/star-wars-app.js
@@ -87,6 +87,10 @@ $(document).ready(function() {
 
             var residentsArray = [];
 
+            if (residentsArray.length < 1) {
+                $("#planet-residents").html("");
+            }
+
             for (i = 0; i < response.results[0].residents.length; i++) {
 
                 residentQueryURL = response.results[0].residents[i];
@@ -135,6 +139,10 @@ $(document).ready(function() {
             generatePopulationGraphic(planetPopulation);
 
             var residentsArray = [];
+
+            if (residentsArray.length < 1) {
+                $("#planet-residents").html("");
+            }
 
             for (var i = 0; i < response.residents.length; i++) {
 


### PR DESCRIPTION
This feature fixes a bug where if a new planet was selected but didn't have any residents, the #planet-residents div displayed the residents of the last planet selected instead of being blank