### PR TITLE
Random Planet HTTPS to HTTP

### DIFF
--- a/star-wars-app/star-wars-app.js
+++ b/star-wars-app/star-wars-app.js
@@ -112,7 +112,7 @@ $(document).ready(function() {
         var random = Math.floor(Math.random() * (61 - 1)) + 1;
 
         // var planet = $(this).attr("data-name");
-        var queryURL = "https://swapi.co/api/planets/" + random;
+        var queryURL = "http://swapi.co/api/planets/" + random;
         console.log(queryURL);
 
         // Creating an AJAX call for the planet chosen at random


### PR DESCRIPTION
This feature changes the API call for random planets from https to http in an attempt to fix the CORS problem